### PR TITLE
changing schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -86,4 +86,5 @@ ActiveRecord::Schema.define(version: 2021_10_15_155527) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
+
 end


### PR DESCRIPTION
Schema was changed where the Deposit and Withdrawal tables are now using "category" instead of "transaction_id" as the foreign key for TransactionTypes.