### PR TITLE
added drivers license/adjusted tests

### DIFF
--- a/app/views/members/_form.html.erb
+++ b/app/views/members/_form.html.erb
@@ -12,8 +12,8 @@
   <% end %>
 
   <div class="field form-group">
-    <%= form.label :UIN, "UIN" %>
-    <%= form.number_field :member_uin, class:"form-control", placeholder: "UIN" %>
+    <%= form.label :UIN, "UIN / Driver's License" %>
+    <%= form.number_field :member_uin, class:"form-control", placeholder: "UIN / Driver's License" %>
   </div>
 
   <div class="field form-group">

--- a/app/views/members/index.html.erb
+++ b/app/views/members/index.html.erb
@@ -24,7 +24,7 @@
 
 <input type="checkbox" onclick="toggleElements_id('fn')" id="fnBox" checked>First Name</input>
 <input type="checkbox" onclick="toggleElements_id('ln')" id="lnBox" checked>Last Name</input>
-<input type="checkbox" onclick="toggleElements_id('uin')" id="uinBox" checked>UIN</input>
+<input type="checkbox" onclick="toggleElements_id('uin')" id="uinBox" checked>UIN/DL</input>
 <input type="checkbox" onclick="toggleElements_id('email')" id="emailBox" checked>Email</input>
 <input type="checkbox" onclick="toggleElements_id('pn')" id="pnBox" checked>Phone Number</input>
 <input type="checkbox" onclick="toggleElements_id('join')" id="joinBox" checked>Join Date</input>
@@ -38,7 +38,7 @@
     <tr>
       <th class= 'fn' style="display: ;"><%= sortable 'first_name'%></th>
       <th class= 'ln' style="display: ;"><%= sortable 'last_name'%></th>
-      <th class= 'uin' style="display: ;"><%= sortable 'member_uin', 'UIN'%></th>
+      <th class= 'uin' style="display: ;"><%= sortable 'member_uin', 'UIN/DL'%></th>
       <th class= 'email' style="display: ;"><%= sortable 'email'%></th>
       <th class= 'pn' style="display: ;"><%= sortable 'phone_number'%></th>
       <th class= 'join' style="display: ;"><%= sortable 'join_date'%></th>

--- a/spec/integration/member_integration_spec.rb
+++ b/spec/integration/member_integration_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Create Member', type: :feature do
     visit new_member_path
     click_link 'Sign in with your TAMU Google Account'
     visit new_member_path
-    fill_in 'UIN', with: '727002594'
+    fill_in "UIN / Driver's License", with: '727002594'
     fill_in 'First Name', with: 'Andres'
     fill_in 'Last Name', with: 'Blanco'
     fill_in 'Email', with: 'andresblanco1785@tamu.edu'
@@ -75,7 +75,7 @@ RSpec.describe 'Create invalid Member', type: :feature do
     visit new_member_path
     click_link 'Sign in with your TAMU Google Account'
     visit new_member_path
-    fill_in 'UIN', with: 'regularCharacters'
+    fill_in "UIN / Driver's License", with: 'regularCharacters'
     fill_in 'First Name', with: 'Michael'
     fill_in 'Last Name', with: 'Stewart'
     fill_in 'Email', with: 'ms@tamu.edu'


### PR DESCRIPTION
edited the html documents so that the UIN field would indicate drivers license. The customers expressed the interest in potentially having non tamu students in their club, so their form of ID would be their drivers license. I changed the sort box and the form (including place holder) to include /Driver's License. Two tests failed because they were looking for the field UIN, I updated them to the new words.